### PR TITLE
Simplify #endRebuild to simply call #asSortedCollection

### DIFF
--- a/src/Aleph/AlpImplementorsIndexWithTable.class.st
+++ b/src/Aleph/AlpImplementorsIndexWithTable.class.st
@@ -50,14 +50,9 @@ AlpImplementorsIndexWithTable >> defaultEntitiesForRebuild [
 
 { #category : #updating }
 AlpImplementorsIndexWithTable >> endRebuild [
-	| temporaryEntries |
 	super endRebuild.
 	
-	temporaryEntries := SortedCollection new: self initialTableSize.
-	entries do: [ :each | temporaryEntries addLast: each ].
-	temporaryEntries reSort.
-	
-	entries := temporaryEntries
+	entries := entries asSortedCollection.
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
`AlpImplementorsIndexWithTable >> endRebuild` can just call `#asSortedCollection` on the collection to obtain the same result.